### PR TITLE
Fix for https://github.com/jezhumble/javasysmon/issues/7

### DIFF
--- a/src/main/java/com/jezhumble/javasysmon/FileUtils.java
+++ b/src/main/java/com/jezhumble/javasysmon/FileUtils.java
@@ -50,9 +50,16 @@ public class FileUtils {
     public byte[] slurpToByteArray(String fileName) throws IOException {
         File fileToRead = new File(fileName);
         byte[] contents = new byte[(int) fileToRead.length()];
-        final InputStream inputStream = new FileInputStream(fileToRead);
-        inputStream.read(contents);
-        return contents;
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(fileToRead);
+            inputStream.read(contents);
+            return contents;
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/jezhumble/javasysmon/UnixPasswdParser.java
+++ b/src/main/java/com/jezhumble/javasysmon/UnixPasswdParser.java
@@ -9,6 +9,11 @@ import java.util.HashMap;
 class UnixPasswdParser {
 
     public HashMap parse(BufferedReader reader) {
+        if (reader == null) {
+            System.err.println("Error parsing password file: reader is null");
+            return new HashMap();
+        }
+
         HashMap users = new HashMap();
         try {
             String line;
@@ -22,6 +27,12 @@ class UnixPasswdParser {
         } catch (IOException e) {
             System.err.println("Error parsing password file: " + e.getMessage());
             return new HashMap();
+        } finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                System.err.println("Error closing reader: " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
I closed the reader in a finally block in UnixPasswdParser#parse and the stream in FileUtils#slurpToByteArray.
This prevented a "Too many open files" in our application
